### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+## 1.0.0 (2015-08-25)
+
+Starting with 1.0.0 as the application is already being used, and we had to
+start somewhere.
+
+List of changes based on merged branches:
+
+* feature/rename-dataset
+* feature/CSV-fields
+* fix/eoo_aoo_analysis_for_current_group
+* fix/coloring-imported-groups
+* feature/symbols-per-group
+* feature/CSV-fields-redux
+* feature/keep-aoo-analysis-on
+* fix/hide-user-points
+* feature/file-name
+* feature/add-group-field-csv 
+* feature/gbif-catalogue-id
+* feature/symbols-changes
+* feature/fix-flickr-gbif-urls
+* feature/inaturalist-research


### PR DESCRIPTION
This release includes several bug fixes and small changes. Numbered 1.0.0, because it's the first release of the repo and we had to start somewhere.

List of changes based on branches merged:
- feature/rename-dataset
- feature/CSV-fields
- fix/eoo_aoo_analysis_for_current_group
- fix/coloring-imported-groups
- feature/symbols-per-group
- feature/CSV-fields-redux
- feature/keep-aoo-analysis-on
- fix/hide-user-points
- feature/file-name
- feature/add-group-field-csv 
- feature/gbif-catalogue-id
- feature/symbols-changes
- feature/fix-flickr-gbif-urls
- feature/inaturalist-research
