### PR TITLE
fixed image-url deprecated in rails 4 in javascript folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@
 
   9. It should be working at [http://localhost:3000](http://localhost:3000)
 
+## Installing using Docker
 
+1. Install [Docker](https://docs.docker.com/installation/#installation)
+
+2. Run the following commands:
+
+```
+docker compose up --build
+```
+
+3. Setup the database (in other terminal window)
+
+```bash
+docker compose run web bundle exec rake db:setup
+```
 
 [The Vizzuality team](https://www.vizzuality.com)

--- a/app/assets/javascripts/editor/Layout/Analysis/analysis_view.js.erb
+++ b/app/assets/javascripts/editor/Layout/Analysis/analysis_view.js.erb
@@ -132,7 +132,7 @@
       // Analysis help :(
       $('#analysis_help').css(
         'background',
-        active ? "image-url('editor/analysis_help2.png') no-repeat -2px 0" : "image-url('editor/analysis_help.png') no-repeat 0 0"
+        active ? "url(<%= asset_url('editor/analysis_help2.png') %>) no-repeat -2px 0" : "url(<%= asset_url('editor/analysis_help.png') %>) no-repeat 0 0"
       );
 
       // Start or finish convex hull

--- a/app/assets/javascripts/editor/MapOverlays/MarkerOverTooltip.js.erb
+++ b/app/assets/javascripts/editor/MapOverlays/MarkerOverTooltip.js.erb
@@ -24,7 +24,7 @@
 				div.style.width = '57px';
 				div.style.height = '22px';
 				div.style.zIndex = global_zIndex;
-				div.style.background = "image-url('editor/over_bkg.png') no-repeat 0 0";
+				div.style.background = "url(<%= asset_url('editor/over_bkg.png') %>) no-repeat 0 0";
 
 				$(div).hover(function(){
 					over_mini_tooltip = true;
@@ -43,7 +43,7 @@
 				button_i.style.top = "4px";
 				button_i.style.width = "14px";
 				button_i.style.height = "14px";
-				button_i.style.background = "image-url('editor/over_i.png') no-repeat 0 0";
+				button_i.style.background = "url(<%= asset_url('editor/over_i.png') %>) no-repeat 0 0";
 				button_i.style.cursor = "pointer";
 				$(button_i).click(function(ev){
 					try{ev.stopPropagation();}catch(e){event.cancelBubble=true;};
@@ -62,7 +62,7 @@
 				button_o.style.top = "4px";
 				button_o.style.width = "14px";
 				button_o.style.height = "14px";
-				button_o.style.background = "image-url('editor/over_o.png') no-repeat 0 0";
+				button_o.style.background = "url(<%= asset_url('editor/over_o.png') %>) no-repeat 0 0";
 				button_o.style.cursor = "pointer";
 				$(button_o).click(function(ev){
 					try{ev.stopPropagation();}catch(e){event.cancelBubble=true;};
@@ -82,7 +82,7 @@
 				button_x.style.top = "4px";
 				button_x.style.width = "14px";
 				button_x.style.height = "14px";
-				button_x.style.background = "image-url('editor/over_x.png') no-repeat 0 0";
+				button_x.style.background = "url(<%= asset_url('editor/over_x.png') %>) no-repeat 0 0";
 				button_x.style.cursor = "pointer";
 				$(button_x).click(function(ev){
 					try{ev.stopPropagation();}catch(e){event.cancelBubble=true;};

--- a/app/assets/javascripts/editor/MapOverlays/PolygonOverTooltip.js.erb
+++ b/app/assets/javascripts/editor/MapOverlays/PolygonOverTooltip.js.erb
@@ -43,7 +43,7 @@
         inner_div.style['float'] = "left";
         inner_div.style.padding = "0 0 0 10px";
     		inner_div.style.height = '22px';
-    		inner_div.style.background = "image-url('editor/left_polygon_tooltip.png') no-repeat left 0";
+    		inner_div.style.background = "url(<%= asset_url('editor/left_polygon_tooltip.png') %>) no-repeat left 0";
     		div.appendChild(inner_div);
 
     		var inner_div2 = document.createElement('div');
@@ -52,7 +52,7 @@
         inner_div2.style['float'] = "left";
         inner_div2.style.padding = "0 40px 0 0";
     		inner_div2.style.height = '22px';
-    		inner_div2.style.background = "image-url('editor/right_polygon_tooltip.png') no-repeat right 0";
+    		inner_div2.style.background = "url(<%= asset_url('editor/right_polygon_tooltip.png') %>) no-repeat right 0";
     		inner_div.appendChild(inner_div2);
 
 
@@ -61,6 +61,7 @@
         points.style.position = "relative";
         points.style.padding = "5px 0 0 0";
         points.style.margin = "0";
+				points.style.whiteSpace = 'nowrap';
     		$(points).text(this.markers.length + ((this.markers.length==1)?' point':' points'));
         points.style.font = "normal 11px Arial";
         points.style.color = "white";
@@ -74,9 +75,10 @@
     		button_o.style.top = "4px";
     		button_o.style.width = "14px";
     		button_o.style.height = "14px";
-    		button_o.style.background = "image-url('editor/over_o.png') no-repeat 0 0";
+    		button_o.style.background = "url(<%= asset_url('editor/over_o.png') %>) no-repeat 0 0";
     		button_o.style.cursor = "pointer";
     		$(button_o).click(function(ev){
+					ev.stopPropagation();
     			me.makeActive();
     			try{ev.stopPropagation();}catch(e){event.cancelBubble=true;};
     		});
@@ -95,7 +97,7 @@
     		button_x.style.top = "4px";
     		button_x.style.width = "14px";
     		button_x.style.height = "14px";
-    		button_x.style.background = "image-url('editor/over_x.png') no-repeat 0 0";
+    		button_x.style.background = "url(<%= asset_url('editor/over_x.png') %>) no-repeat 0 0";
     		button_x.style.cursor = "pointer";
     		$(button_x).click(function(ev){
     		  me.deleteMarker();

--- a/app/assets/javascripts/editor/Models/HullOperations.js.erb
+++ b/app/assets/javascripts/editor/Models/HullOperations.js.erb
@@ -41,7 +41,7 @@
 						$(this).parent().children().removeClass('disabled');
 						$(this).find('span').stop().animate({backgroundPosition:'-3px -25px', backgroundColor:'#A6DD3A'}, 100);
 						$('div.analysis_data').stop().animate({height: '144px'}, 'fast',function(ev){$(this).css('overflow','auto');});
-						$('#analysis_help').css('background',"image-url('editor/analysis_help2.png') no-repeat -2px 0");
+						$('#analysis_help').css('background',"url(<%= asset_url('editor/analysis_help2.png') %>) no-repeat -2px 0");
 					} else {
 					  // $('body').unbind('click');
 					  $('div.sources').stop().animate({top: '85px'},'fast');
@@ -50,7 +50,7 @@
 						$(this).parent().children('h3').addClass('disabled');
 						$(this).find('span').stop(true).animate({backgroundPosition:'-26px -25px', backgroundColor:'#999999'}, 100);
 						$('div.analysis_data').stop().animate({height: '0'}, 'fast',function(ev){$(this).css('overflow','auto');});
-						$('#analysis_help').css('background',"image-url('editor/analysis_help.png') no-repeat 0 0");
+						$('#analysis_help').css('background',"url(<%= asset_url('editor/analysis_help.png') %>) no-repeat 0 0");
 					}
 				});
 

--- a/app/assets/javascripts/editor/Models/MainApp.js.erb
+++ b/app/assets/javascripts/editor/Models/MainApp.js.erb
@@ -1,6 +1,6 @@
 
   function mainApp() {
-    $('body').css('background','image-url(\'editor/bkg.jpg\') 0 0');
+		$('body').css('background', "url(<%= asset_url('editor/bkg.jpg') %>) 0 0");
 
     //Get report name and bind report name events
     report_name = $('h1 p').text();

--- a/app/assets/javascripts/editor/Models/MapOperations.js.erb
+++ b/app/assets/javascripts/editor/Models/MapOperations.js.erb
@@ -120,13 +120,13 @@
 				//Change cursor depending on application state
 				google.maps.event.addListener(map,"mouseover",function(event){
 						switch(state) {
-							case 'add': 			map.setOptions({draggableCursor: "image-url('editor/add_cursor.png'),default"});
+							case 'add': 			map.setOptions({draggableCursor: "url(<%= asset_url('editor/add_cursor.png') %>),default"});
 																break;
-							case 'selection': map.setOptions({draggableCursor: "image-url('editor/selection_cursor.png'),default"});
+							case 'selection': map.setOptions({draggableCursor: "url(<%= asset_url('editor/selection_cursor.png') %>),default"});
 																break;
-							case 'remove': 		map.setOptions({draggableCursor: "image-url('editor/remove_cursor.png'),default"});
+							case 'remove': 		map.setOptions({draggableCursor: "url(<%= asset_url('editor/remove_cursor.png') %>),default"});
 																break;
-							default: 					map.setOptions({draggableCursor: "image-url('editor/default_cursor.png'),default"});
+							default: 					map.setOptions({draggableCursor: "url(<%= asset_url('editor/default_cursor.png') %>),default"});
 						}
 				});
 
@@ -246,7 +246,7 @@
 			/* Show loading map stuff. 																										*/
 			/*============================================================================*/
 			function showMamufasMap() {
-				$('#mamufas_map').css('background',"image-url('editor/mamufas_bkg.png') repeat 0 0");
+				$('#mamufas_map').css('background',"url(<%= asset_url('editor/mamufas_bkg.png') %>) repeat 0 0");
 				$('#mamufas_map').fadeIn();
 				$('#loader_map').fadeIn();
 			}

--- a/app/assets/javascripts/home/HomeMarker.js.erb
+++ b/app/assets/javascripts/home/HomeMarker.js.erb
@@ -44,11 +44,11 @@ HomeMarker.prototype.createElement = function() {
   if (!div) {
     var random = Math.random();
 		if (random<0.33) {
-			var image = '<%= asset_url('editor/gbif_marker.png') %>';
+			var image = "<%= asset_url('editor/gbif_marker.png') %>";
 		} else if (random>0.32&&random<0.66) {
-			var image = '<%= asset_url('editor/flickr_marker.png') %>';
+			var image = "<%= asset_url('editor/flickr_marker.png') %>";
 		} else {
-			var image = '<%= asset_url('editor/user_marker.png') %>';
+			var image = "<%= asset_url('editor/user_marker.png') %>";
 		}
 
     div = this.div_ = document.createElement("div");
@@ -83,7 +83,7 @@ HomeMarker.prototype.createElement = function() {
     $(inner).css('-webkit-border-radius','5px');
     $(inner).css('border-radius','5px');
     $(inner).css('-moz-border-radius','5px');
-    inner.style.background = "image-url('"+image+"') no-repeat center center";
+    inner.style.background = "url('"+image+"') no-repeat center center";
     inner.style.width = "0";
     inner.style.height = "0";
     inner.style.opacity = "0";

--- a/app/assets/javascripts/plugins/jquery.autocomplete.js.erb
+++ b/app/assets/javascripts/plugins/jquery.autocomplete.js.erb
@@ -725,7 +725,7 @@ $.Autocompleter.Select = function (options, input, select, config) {
 			}
 		},
 		hide: function() {
-			$('form.up').css('background','url(/assets/home/form_bkg.png) no-repeat 200px 300px');
+			$('form.up').css('background',"url(<%= asset_url('home/form_bkg.png') no-repeat 200px 300px");
 			element && element.hide();
 			listItems && listItems.removeClass(CLASSES.ACTIVE);
 			active = -1;
@@ -738,7 +738,7 @@ $.Autocompleter.Select = function (options, input, select, config) {
 		},
 		show: function() {
 			var offset = $(input).offset();
-			$('form.up').css('background','url(/assets/home/form_bkg.png) no-repeat 3px 0');
+			$('form.up').css('background', "url(<%= asset_url('home/form_bkg.png') no-repeat 3px 0");
 			
 			element.css({
 				width: typeof options.width == "string" || options.width > 0 ? options.width : $(input).width(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: bundle exec rails s -b 0.0.0.0
+    command: ./entrypoint.sh
     environment:
       - RAILS_ENV=development
       - POSTGRES_HOST=db


### PR DESCRIPTION
This issue doesn't allow to show the images inside the javascript folders because it was using `image-url` instead of `url`